### PR TITLE
Fix Transaction Dispose

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <TargetFrameworks>netcoreapp1.0;netcoreapp1.1;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2;net46;netstandard2.0</TargetFrameworks>
-    <VersionPrefix>0.19.2</VersionPrefix>
+    <VersionPrefix>0.19.3</VersionPrefix>
     <AssemblyVersion>0.11.0.0</AssemblyVersion>
     <FileVersion>$(VersionPrefix)</FileVersion>
     <Authors>dataaction</Authors>

--- a/src/AdoNetCore.AseClient/AdoNetCore.AseClient.csproj
+++ b/src/AdoNetCore.AseClient/AdoNetCore.AseClient.csproj
@@ -5,5 +5,7 @@
   </PropertyGroup>
 <PropertyGroup>
    <LangVersion>7</LangVersion>
+   <IncludeSymbols>True</IncludeSymbols>
+   <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 </PropertyGroup>
 </Project>

--- a/src/AdoNetCore.AseClient/AseConnection.cs
+++ b/src/AdoNetCore.AseClient/AseConnection.cs
@@ -361,7 +361,7 @@ namespace AdoNetCore.AseClient
         public override ConnectionState State => InternalState;
         private ConnectionState InternalState
         {
-            get => _state;
+            get => _internal != null && _internal.IsDoomed ? ConnectionState.Broken : _state;
             set
             {
                 if (_isDisposed)

--- a/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/AseConnectionTests.cs
@@ -278,5 +278,23 @@ namespace AdoNetCore.AseClient.Tests.Unit
 
             return mockConnectionPoolManager.Object;
         }
+        [Test]
+        public void DoomedReturnsBroken()
+        {
+            var mockConnection = new Mock<IInternalConnection>();
+            var mockConnectionPoolManager = new Mock<IConnectionPoolManager>();
+
+            mockConnectionPoolManager
+                .Setup(x => x.Reserve(It.IsAny<string>(), It.IsAny<ConnectionParameters>(), It.IsAny<IInfoMessageEventNotifier>(), It.IsAny<RemoteCertificateValidationCallback>()))
+                .Returns(mockConnection.Object);
+
+            mockConnection.SetupGet(x => x.IsDoomed).Returns(true);
+
+            using (var connection = new AseConnection("Data Source=myASEserver;Port=5000;Database=foo;Uid=myUsername;Pwd=myPassword;", mockConnectionPoolManager.Object))
+            {
+                connection.Open();
+                Assert.AreEqual(ConnectionState.Broken, connection.State);
+            }
+        }
     }
 }

--- a/test/AdoNetCore.AseClient.Tests/Unit/AseTransactionTests.cs
+++ b/test/AdoNetCore.AseClient.Tests/Unit/AseTransactionTests.cs
@@ -1,4 +1,4 @@
-﻿using System.Data;
+using System.Data;
 using Moq;
 using NUnit.Framework;
 
@@ -199,6 +199,7 @@ namespace AdoNetCore.AseClient.Tests.Unit
                 .Returns(mockCommandBeginTransaction.Object)
                 .Returns(mockCommandRollbackTransaction.Object);
 
+            mockConnection.Setup(x => x.State).Returns(ConnectionState.Open);
 
             // Act
             var connection = mockConnection.Object;
@@ -271,6 +272,204 @@ namespace AdoNetCore.AseClient.Tests.Unit
 
             transaction.Dispose(); // Implicit rollback
             transaction.Dispose(); // Should do nothing
+        }
+        [Test]
+        public void ImplicitRollback_WithValidTransaction_DisposeFromUsing()
+        {
+            // Arrange
+            var mockConnection = new Mock<IDbConnection>();
+            var isolationLevel = IsolationLevel.Serializable;
+
+            var mockCommandIsolationLevel = new Mock<IDbCommand>();
+            var mockCommandBeginTransaction = new Mock<IDbCommand>();
+            var mockCommandRollbackTransaction = new Mock<IDbCommand>();
+
+            mockCommandIsolationLevel
+                .SetupAllProperties()
+                .Setup(x => x.ExecuteNonQuery())
+                .Returns(0);
+
+            mockCommandBeginTransaction
+                .SetupAllProperties()
+                .Setup(x => x.ExecuteNonQuery())
+                .Returns(0);
+
+            mockCommandRollbackTransaction
+                .SetupAllProperties()
+                .Setup(x => x.ExecuteNonQuery())
+                .Returns(0);
+
+            mockConnection
+                .Setup(x => x.BeginTransaction(isolationLevel))
+                .Returns(() => {
+                    // Simulate what AseConnection.BeginTransaction() does.
+                    var t = new AseTransaction(mockConnection.Object, isolationLevel);
+                    t.Begin();
+                    return t;
+                });
+
+            mockConnection
+                .SetupSequence(x => x.CreateCommand())
+                .Returns(mockCommandIsolationLevel.Object)
+                .Returns(mockCommandBeginTransaction.Object)
+                .Returns(mockCommandRollbackTransaction.Object);
+
+            mockConnection.Setup(x => x.State).Returns(ConnectionState.Open);
+
+
+            // Act
+            using (var connection = mockConnection.Object)
+            {
+                using (var transaction = connection.BeginTransaction(isolationLevel))
+                {
+                    // Do nothing
+                }
+            }
+
+            // Assert
+            mockCommandIsolationLevel.VerifySet(x => { x.CommandText = "SET TRANSACTION ISOLATION LEVEL 3"; });
+            mockCommandIsolationLevel.VerifySet(x => { x.CommandType = CommandType.Text; });
+            mockCommandIsolationLevel.Verify();
+
+            mockCommandBeginTransaction.VerifySet(x => { x.CommandText = "BEGIN TRANSACTION"; });
+            mockCommandBeginTransaction.VerifySet(x => { x.CommandType = CommandType.Text; });
+            mockCommandBeginTransaction.Verify();
+
+            mockCommandRollbackTransaction.VerifySet(x => { x.CommandText = "ROLLBACK TRANSACTION"; });
+            mockCommandRollbackTransaction.VerifySet(x => { x.CommandType = CommandType.Text; });
+            mockCommandRollbackTransaction.Verify();
+        }
+        [Test]
+        public void ImplicitRollback_ClosedConnection_DisposeFromUsing()
+        {
+            // Arrange
+            var mockConnection = new Mock<IDbConnection>();
+            var isolationLevel = IsolationLevel.Serializable;
+
+            var mockCommandIsolationLevel = new Mock<IDbCommand>();
+            var mockCommandBeginTransaction = new Mock<IDbCommand>();
+            var mockCommandRollbackTransaction = new Mock<IDbCommand>();
+
+            mockCommandIsolationLevel
+                .SetupAllProperties()
+                .Setup(x => x.ExecuteNonQuery())
+                .Returns(0);
+
+            mockCommandBeginTransaction
+                .SetupAllProperties()
+                .Setup(x => x.ExecuteNonQuery())
+                .Returns(0);
+
+            mockCommandRollbackTransaction
+                .SetupAllProperties()
+                .Setup(x => x.ExecuteNonQuery())
+                .Returns(0);
+
+            mockConnection
+                .Setup(x => x.BeginTransaction(isolationLevel))
+                .Returns(() => {
+                    // Simulate what AseConnection.BeginTransaction() does.
+                    var t = new AseTransaction(mockConnection.Object, isolationLevel);
+                    t.Begin();
+                    return t;
+                });
+
+            mockConnection
+                .SetupSequence(x => x.CreateCommand())
+                .Returns(mockCommandIsolationLevel.Object)
+                .Returns(mockCommandBeginTransaction.Object)
+                .Returns(mockCommandRollbackTransaction.Object);
+
+            mockConnection.Setup(x => x.State).Returns(ConnectionState.Closed);
+
+
+            // Act
+            using (var connection = mockConnection.Object)
+            {
+                using (var transaction = connection.BeginTransaction(isolationLevel))
+                {
+                    // Do nothing
+                }
+            }
+
+            // Assert
+            mockCommandIsolationLevel.VerifySet(x => { x.CommandText = "SET TRANSACTION ISOLATION LEVEL 3"; });
+            mockCommandIsolationLevel.VerifySet(x => { x.CommandType = CommandType.Text; });
+            mockCommandIsolationLevel.Verify();
+
+            mockCommandBeginTransaction.VerifySet(x => { x.CommandText = "BEGIN TRANSACTION"; });
+            mockCommandBeginTransaction.VerifySet(x => { x.CommandType = CommandType.Text; });
+            mockCommandBeginTransaction.Verify();
+
+            mockCommandRollbackTransaction.VerifySet(x => x.CommandText = "ROLLBACK TRANSACTION", Times.Never);
+            mockCommandRollbackTransaction.VerifySet(x => x.CommandType = CommandType.Text, Times.Never);
+            mockCommandRollbackTransaction.Verify(x => x.ExecuteNonQuery(), Times.Never);
+        }
+        [Test]
+        public void ImplicitRollback_BrokenConnection_DisposeFromUsing()
+        {
+            // Arrange
+            var mockConnection = new Mock<IDbConnection>();
+            var isolationLevel = IsolationLevel.Serializable;
+
+            var mockCommandIsolationLevel = new Mock<IDbCommand>();
+            var mockCommandBeginTransaction = new Mock<IDbCommand>();
+            var mockCommandRollbackTransaction = new Mock<IDbCommand>();
+
+            mockCommandIsolationLevel
+                .SetupAllProperties()
+                .Setup(x => x.ExecuteNonQuery())
+                .Returns(0);
+
+            mockCommandBeginTransaction
+                .SetupAllProperties()
+                .Setup(x => x.ExecuteNonQuery())
+                .Returns(0);
+
+            mockCommandRollbackTransaction
+                .SetupAllProperties()
+                .Setup(x => x.ExecuteNonQuery())
+                .Returns(0);
+
+            mockConnection
+                .Setup(x => x.BeginTransaction(isolationLevel))
+                .Returns(() => {
+                    // Simulate what AseConnection.BeginTransaction() does.
+                    var t = new AseTransaction(mockConnection.Object, isolationLevel);
+                    t.Begin();
+                    return t;
+                });
+
+            mockConnection
+                .SetupSequence(x => x.CreateCommand())
+                .Returns(mockCommandIsolationLevel.Object)
+                .Returns(mockCommandBeginTransaction.Object)
+                .Returns(mockCommandRollbackTransaction.Object);
+
+            mockConnection.Setup(x => x.State).Returns(ConnectionState.Broken);
+
+
+            // Act
+            using (var connection = mockConnection.Object)
+            {
+                using (var transaction = connection.BeginTransaction(isolationLevel))
+                {
+                    // Do nothing
+                }
+            }
+
+            // Assert
+            mockCommandIsolationLevel.VerifySet(x => { x.CommandText = "SET TRANSACTION ISOLATION LEVEL 3"; });
+            mockCommandIsolationLevel.VerifySet(x => { x.CommandType = CommandType.Text; });
+            mockCommandIsolationLevel.Verify();
+
+            mockCommandBeginTransaction.VerifySet(x => { x.CommandText = "BEGIN TRANSACTION"; });
+            mockCommandBeginTransaction.VerifySet(x => { x.CommandType = CommandType.Text; });
+            mockCommandBeginTransaction.Verify();
+
+            mockCommandRollbackTransaction.VerifySet(x => x.CommandText = "ROLLBACK TRANSACTION", Times.Never);
+            mockCommandRollbackTransaction.VerifySet(x => x.CommandType = CommandType.Text, Times.Never);
+            mockCommandRollbackTransaction.Verify(x => x.ExecuteNonQuery(), Times.Never);
         }
     }
 }


### PR DESCRIPTION
Do not allow exceptions out of AseTransaction.Dispose.
Regardless of the outcome of calling Rollback in Dispose, set _isDisposed to true.
Only call Rollback from Dispose if the connection is in the Open state.
Write unit tests for the Dispose issue.
Bump the version number.